### PR TITLE
Rewrite with tests and Habitat support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+results/
+__pycache__

--- a/.studiorc
+++ b/.studiorc
@@ -1,0 +1,4 @@
+hab install core/python37
+hab pkg binlink core/python37 python
+python -m pip install pylint
+python -m pip install praw

--- a/README.md
+++ b/README.md
@@ -4,14 +4,45 @@
 
 This is a simple branding bot for VMware. This periodically checks a few subreddits then comments when someone spells VMware as `VMWare`.
 
-## Running
+## Running via Python
 
-1) First create an app as a "script" here: https://www.reddit.com/prefs/apps
+1. First create an app as a "script" here: https://www.reddit.com/prefs/apps
 
-2) Run the command with these three ENV variables
-```
-$ PASSWORD='VMware123!' CLIENT_ID='my_client_id1' CLIENT_SECRET=atotallysecretclientthingy2 python3 vmware_reddit_bot.py
-```
+1. Run the command with these ENV variables:
+
+    ```
+    PASSWORD='VMware123!' \
+    CLIENT_ID='my_client_id1' \
+    CLIENT_SECRET='atotallysecretclientthingy2' \
+    SUBREDDITS='a_subreddit anotehr_subreddit' \
+    REDDIT_USERNAME='your_reddit_username' \
+    BOT_REPLY_MESSAGE='The message you'd like to use as the reply' \
+    python3 vmware_reddit_bot.py
+    ```
+
+## Running via Habitat
+
+1. First create an app as a "script" here: https://www.reddit.com/prefs/apps
+1. Setup Habitat (see: [https://www.habitat.sh/docs/install-habitat/](https://www.habitat.sh/docs/install-habitat/))
+1. Run `hab pkg build .`
+1. Create `/hab/user/vmware_reddit_bot/config/user.toml` based on `habitat/default.toml`
+1. Run `hab run results/yourorigin-vmware_reddit_bot*`
+
+> For running as a service see: [https://www.habitat.sh/docs/best-practices/#running-habitat-servers](https://www.habitat.sh/docs/best-practices/#running-habitat-servers)
+
+## Testing via Habitat
+
+### Unit Tests
+
+1. Setup Habitat (see: [https://www.habitat.sh/docs/install-habitat/](https://www.habitat.sh/docs/install-habitat/))
+1. Run `hab studio enter`
+1. Run `python -m unittest tests/vmware_reddit_bot_tests.py`
+
+### Lint Tests
+
+1. Setup Habitat (see: [https://www.habitat.sh/docs/install-habitat/](https://www.habitat.sh/docs/install-habitat/))
+1. Run `hab studio enter`
+1. Run `python -m pylint path_to_file.py`
 
 ## License and Author
 Author:: JJ Asghar <jjasghar@gmail.com>

--- a/comments_replied_to.txt
+++ b/comments_replied_to.txt
@@ -1,4 +1,3 @@
-
 e3ue0zy
 e3ue1a0
 e3ue2e0

--- a/habitat/README.md
+++ b/habitat/README.md
@@ -1,0 +1,9 @@
+# Habitat package: vmware_reddit_bot
+
+## Description
+
+Allows you to run the VMware reddit bot without having to deal with python
+
+## Usage
+
+Modify setting in default.toml (or use user.toml) to suite your needs, build the Habitat package, run the Habitat package.

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -1,0 +1,8 @@
+bot_password = 'yourpassword'
+bot_client_id = 'yourclientid'
+bot_client_secret = 'yourclientsecret'
+
+reddit_username = 'yourusernamehere'
+subreddits = ['test']
+
+bot_reply_message = "A friendly note, the official branding of [VMware](https://www.vmware.com/) is without a capital 'W'. Take a look [here](https://www.vmware.com/brand/our-brand.html) if you'd like more details. _Beep Boop I'm a bot if you have questions or suggestions please message /u/yourusernamehere about it_."

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -1,0 +1,10 @@
+exec 2>&1
+
+export PASSWORD={{cfg.bot_password}}
+export CLIENT_ID={{cfg.bot_client_id}}
+export CLIENT_SECRET={{cfg.bot_client_secret}}
+export SUBREDDITS="{{strJoin cfg.subreddits " "}}"
+export REDDIT_USERNAME="{{cfg.reddit_username}}"
+export BOT_REPLY_MESSAGE="{{cfg.bot_reply_message}}"
+
+exec python {{pkg.path}}/bin/{{pkg.name}}.py

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,0 +1,28 @@
+pkg_name=vmware_reddit_bot
+pkg_version="0.1.0"
+pkg_maintainer="No one in particular"
+pkg_license=("Apache-2.0")
+pkg_deps=(core/python37)
+pkg_lib_dirs=(lib)
+pkg_bin_dirs=(bin)
+
+do_unpack() {
+  return 0
+}
+
+do_build() {
+  return 0
+}
+
+do_setup_environment() {
+  push_runtime_env PYTHONPATH ${pkg_prefix}/lib/python3.7/site-packages
+}
+
+do_install() {
+  cp -R $PLAN_CONTEXT/../* $CACHE_PATH
+  pushd $CACHE_PATH 2>/dev/null
+  mkdir -p ${pkg_prefix}/lib/python3.7/site-packages
+  python setup.py install --prefix ${pkg_prefix} --no-compile
+  cp vmware_reddit_bot.py ${pkg_prefix}/bin
+  cp comments_replied_to.txt ${pkg_prefix}/bin
+}

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+from setuptools import setup
+
+setup(name='vmware_reddit_bot',
+      version='1.0',
+      description='Python Distribution Utilities',
+      author='Someone',
+      author_email='someone@somewhere.com',
+      py_modules=['vmware_reddit_bot'],
+      install_requires=['praw'],
+     )

--- a/tests/vmware_reddit_bot_tests.py
+++ b/tests/vmware_reddit_bot_tests.py
@@ -1,0 +1,102 @@
+"Test file for the VMware Reddit bot"
+import os
+import sys
+import io
+import unittest
+from unittest.mock import patch
+from unittest.mock import Mock
+from unittest.mock import MagicMock
+
+import vmware_reddit_bot as bot
+
+class VMwareRedditBotTest(unittest.TestCase):
+    "Tests for VMware Reddit bot"
+    def setUp(self):
+        "Test #bot_login"
+        os.environ['CLIENT_ID'] = 'fake_client_id'
+        os.environ['CLIENT_SECRET'] = 'fake_client_secret'
+        os.environ['PASSWORD'] = 'fake_password'
+        os.environ['REDDIT_USERNAME'] = 'fake_reddit_username'
+        os.environ['SUBREDDITS'] = "test test2"
+
+    @staticmethod
+    def test_bot_login():
+        "Test #bot_login"
+        with patch('praw.Reddit') as mock_praw:
+            bot.bot_login()
+            agent = '<console:branding_bot:0.0.1 (by /u/fake_reddit_username)'
+            mock_praw.assert_called_with(client_id='fake_client_id',
+                                         client_secret='fake_client_secret',
+                                         password='fake_password',
+                                         user_agent=agent,
+                                         username='branding_bot')
+    @patch('time.sleep')
+    def test_handle_rate_limit(self, mock_time):
+        "Test #handle_rate_limit"
+        output_capture = io.StringIO()
+        sys.stdout = output_capture
+        bot.handle_rate_limit('10 seconds')
+        self.assertEqual(output_capture.getvalue(), '10 seconds\n')
+        mock_time.assert_called_with(10)
+
+        output_capture = io.StringIO()
+        sys.stdout = output_capture
+        bot.handle_rate_limit('10 minutes')
+        self.assertEqual(output_capture.getvalue(), '10 minutes\n')
+        mock_time.assert_called_with(600)
+
+    @patch('builtins.open')
+    def test_save_comment(self, mock_open):
+        "Test #save_comment"
+        mock_open.return_value = MagicMock()
+        file_handle = mock_open.return_value.__enter__.return_value
+
+        self.assertEqual(bot.save_comment(["one"], "two"), ["one", "two"])
+
+        mock_open.assert_called_with("comments_replied_to.txt", "a")
+        file_handle.write.assert_called_with("two\n")
+
+    @patch('praw.Reddit')
+    def test_check_comment(self, mock_praw):
+        "Test #check_comment"
+
+        # True if VMWare (and author is not bot and we have not replied already)
+        mock_comment = MagicMock(body=" VMWare", id='1')
+        mock_comment.author.name = 'user'
+        self.assertTrue(bot.check_comment(mock_comment, mock_praw, []))
+
+        # False if VMware
+        mock_comment = MagicMock(body="VMware", id='1')
+        mock_comment.author.name = 'user'
+        self.assertFalse(bot.check_comment(mock_comment, mock_praw, []))
+
+        # False if bot is comment author
+        mock_comment = MagicMock(body="VMWare", id='1')
+        mock_comment.author.name = 'bot'
+        mock_praw.user.me.return_value.name = 'bot'
+        self.assertFalse(bot.check_comment(mock_comment, mock_praw, []))
+
+        # False if already replied
+        mock_comment = MagicMock(body="VMWare", id='1')
+        mock_comment.author.name = 'user'
+        self.assertFalse(bot.check_comment(mock_comment, mock_praw, ['1']))
+
+    @patch('builtins.open')
+    @patch('os.path')
+    def test_get_saved_comments(self, mock_path, mock_open):
+        "Test #get_saved_comments"
+        with self.assertRaisesRegex(RuntimeError, ".*Cannot find.*"):
+            mock_path.isfile.return_value = False
+            bot.get_saved_comments()
+
+        mock_open.return_value = MagicMock()
+        mock_path.isfile.return_value = True
+        file_handle = mock_open.return_value.__enter__.return_value
+        file_handle.read.return_value = "comment1\ncomment2"
+        self.assertEqual(bot.get_saved_comments(), ['comment1', 'comment2'])
+
+
+    # TODO: Write tests for #run_bot
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Had some time over the weekend to hack on this.

This is a rewrite for Habitat support and unit testing. I haven't tested the bots performance, but this should be a bit more predictable.

There is still a lot to be done.

Mainly:
  - Making running via script easier (too many env vars)
  - Unit tests for `#run_bot`
  - Removing `comments_replied_to.txt` in favor of smarter bot behavior (scanning child comments)
  - ...Actual functional tests
